### PR TITLE
fix conflict ssce/psd pivot

### DIFF
--- a/cui/source/convertToSS.cpp
+++ b/cui/source/convertToSS.cpp
@@ -816,8 +816,7 @@ void	ConvertToSS::makeSsceFile(SSOptionReader& option)
 							break;
 						}
 					}
-				}
-				if ( params.is_layerPivotUse == true)
+				}else if ( params.is_layerPivotUse == true)	//ssceを読まないときにはピボットを書き込む
 				{
 					//原点レイヤーを適用する場合は検索して適用する
 					for (size_t j = 0; j < num; j++)
@@ -825,7 +824,9 @@ void	ConvertToSS::makeSsceFile(SSOptionReader& option)
 						SSSpriteSheetPrim pw = packer.GetPrimitiveInfo(j);
 						if (pw.layertype == LAYERTYPE_PIVOT)
 						{
-							if (p.name == pw.name.substr(1, pw.name.length() - 1))
+
+							std::string primitiveLayerName = pw.name.substr(1, pw.name.length() - 1);
+							if (p.name == primitiveLayerName)
 							{
 								//同じ名前のレイヤーが存在した
 								if (pw.nodata == true)

--- a/cui/source/parameters.h
+++ b/cui/source/parameters.h
@@ -14,13 +14,13 @@ public:
 	int pack_padding;
 	int addpri;
 
-	bool is_ssaeoutput;
-	bool is_sspjoutput;
-	bool is_addnull;
-	bool is_overwrite;
-	bool is_layerPivotUse;
-	bool is_rootLayerUse;
-	bool is_oldPivotUse;
+	bool is_ssaeoutput;		//ssae出力
+	bool is_sspjoutput;		//sspj出力
+	bool is_addnull;		//親NULLパーツ追加
+	bool is_overwrite;		//ssae sspj上書き
+	bool is_layerPivotUse;	//原点レイヤー適用
+	bool is_rootLayerUse;	//rootレイヤー適用
+	bool is_oldPivotUse;	//SSCE読み込み
 	int sortmode;
 	int padding_border;
 	int canvasSize;


### PR DESCRIPTION
SSCEを読み込んでいないときのみPSD側の原点設定を有効にした