### PR TITLE
出力ディレクトリの設定について

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -102,10 +102,19 @@ MainWindow::MainWindow(QWidget *parent) :
 //    data_path += "/SpriteStudio/PSDtoSS6";
 	data_path += TOOLFOLDER;
 	qDebug() << "data_path " << data_path;
-
+	
+	//出力フォルダのパスを確認
+	if(Outputpath == "")
+	{
+		Outputpath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+		Outputpath += "/SpriteStudio/PSDtoSS6";
+	}
+		
     QDir dir;
     //設定ファイル保存用ディレクトリを作成
     dir.mkpath(data_path);
+	//出力フォルダのディレクトリを作成
+	dir.mkpath(Outputpath);
 }
 
 MainWindow::~MainWindow()
@@ -479,7 +488,7 @@ void MainWindow::processFinished( int exitCode, QProcess::ExitStatus exitStatus)
 
 //出力フォルダ選択ボタン
 void MainWindow::on_pushButton_output_clicked()
-{
+{	
     QString str;
     str = QFileDialog::getExistingDirectory(this, tr("Output Directory"), Outputpath);
 
@@ -490,6 +499,11 @@ void MainWindow::on_pushButton_output_clicked()
         ui->textBrowser_output->setText(Outputpath);
     }
 
+	//出力ディレクトリが空白なら"Documents"を設定
+	if(Outputpath == "")
+	{
+		Outputpath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+	}
 }
 
 //リストの読み込み
@@ -568,8 +582,11 @@ void MainWindow::on_pushButton_fileadd_clicked()
 {
     QFileDialog::Options options;
     QString strSelectedFilter;
+	QString openFolderName;
     QString addfileName;
-    addfileName = QFileDialog::getOpenFileName(this, tr("select convert File"), ".", tr("data(*.ss6-psdtoss6-info *.psd)"), &strSelectedFilter, options);
+	//ユーザーのドキュメントフォルダを指定
+	openFolderName = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    addfileName = QFileDialog::getOpenFileName(this, tr("select convert File"), openFolderName, tr("data(*.ss6-psdtoss6-info *.psd)"), &strSelectedFilter, options);
 
     if ( addfileName != "" )
     {


### PR DESCRIPTION

ブランチをISSUE059として再度プルリクを試みています。

PSDtoSS6(GUI)の挙動を見直しました。

1. まず、アプリケーション起動時の出力フォルダがexeファイルの位置から"C:\Users\(ユーザー名)\Documents\SpriteStudio\PSDtoSS6"に変更しました。(mainwindow.cpp,MainWindow:MainWindow( ). 107行~111行
2. 次に、「ファイル追加」ボタンを押したときにダイアログが開かれるが、このとき参照される場所が
"C:\\Users\\(ユーザー名)\\Documents\\"に変更しました。(mainwindow.cpp,MainWindow::on_pushButton_fileadd_clicked(), 585行~588行
3. 最後に「出力フォルダ選択」ボタンを押したときにダイアログが開かれるが、現在設定されている出力フォルダで開かれるように変更しました。ただし上記1.で指定しているSpriteStudio/PSDtoSS6のディレクトリが見つからずSpriteStudioで開かれてしまうため、上記1.の後にSpriteStudio/PSDtoSS6にディレクトリを作成する処理を追加した。
また、「出力フォルダ選択」ボタンの処理に出力フォルダが空白(未指定)のときに"C:\\Users\\(ユーザー名)\\Documents\\"を指定するように変更しました。