### PR TITLE
rootディレクトリを選択したときの挙動を変更

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -523,6 +523,14 @@ void MainWindow::on_pushButton_output_clicked()
     QString str;
     str = QFileDialog::getExistingDirectory(this, tr("Output Directory"), Outputpath);
 
+    //選択されたフォルダがrootなら書き込めないので止める
+    if(QDir(str).isRoot())
+    {
+        QMessageBox::warning(this, tr("sorry!"), tr("not use root"));
+
+         str="";
+    }
+
     if ( str != "" ){//選択されたフォルダ名
         Outputpath = str;
     }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -345,6 +345,20 @@ void MainWindow::on_pushButton_convert_clicked()
         msgBox.exec();
         return;
     }
+    else
+    {
+        //書き込めるフォルダか確かめる
+        QString folder = ui->textBrowser_output->toPlainText();
+        QFile testDir(folder + "_accessTest.txt");
+        if(false == testDir.open(QIODevice::WriteOnly | QIODevice::Text))
+        {
+            QMessageBox msgBox(this);
+            msgBox.setText(tr("an output folder is not writable"));
+            msgBox.exec();
+            return;
+        }
+        testDir.remove();
+    }
 
     if (( ui->listWidget->count() > 0 ) && (convert_exec == false))
     {
@@ -522,14 +536,6 @@ void MainWindow::on_pushButton_output_clicked()
 {
     QString str;
     str = QFileDialog::getExistingDirectory(this, tr("Output Directory"), Outputpath);
-
-    //選択されたフォルダがrootなら書き込めないので止める
-    if(QDir(str).isRoot())
-    {
-        QMessageBox::warning(this, tr("sorry!"), tr("not use root"));
-
-         str="";
-    }
 
     if ( str != "" ){//選択されたフォルダ名
         Outputpath = str;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -538,7 +538,7 @@ void MainWindow::on_pushButton_output_clicked()
         Outputpath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     }
 
-    #if _WIN32
+    #if Q_WS_WIN
             Outputpath += "\\";
     #else
             Outputpath += "/";

--- a/gui/subwindow.cpp
+++ b/gui/subwindow.cpp
@@ -89,6 +89,7 @@ void subwindow::Preview(
 
     //翻訳
     translateUI();
+    ui->retranslateUi(this);
 }
 
 void subwindow::DisplayPreview()


### PR DESCRIPTION
rootディレクトリは書き込みに失敗するため、選択した場合にはドキュメント位置に変更する処理を行う